### PR TITLE
Add missing libxcb* dev libraries for ubuntu 20.04

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libx11-xcb-dev \
     libxcb-dri2-0 \
     libxcb-dri2-0-dev \
+    libxcb-dri3-dev \
+    libxcb-present-dev \
+    libxcb-xfixes0-dev \
     libxdamage1 \
     libxdamage-dev \
     libxext6 \


### PR DESCRIPTION
Ubuntu 20.04 requires these three extra packages to build, but Debian 12 does not require.
```
libxcb-dri3-dev
libxcb-present-dev
libxcb-xfixes0-dev
```

fixes:
```
dpkg-shlibdeps: error: cannot find library libxcb-dri3.so.0 needed by debian/libmali-bifrost-g52-g24p0-x11-wayland-gbm/usr/lib/aarch64-linux-gnu/libmali.so.1.9.0 (ELF format: 'elf64-littleaarch64' abi: '020100b700000000'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libxcb-xfixes.so.0 needed by debian/libmali-bifrost-g52-g24p0-x11-wayland-gbm/usr/lib/aarch64-linux-gnu/libmali.so.1.9.0 (ELF format: 'elf64-littleaarch64' abi: '020100b700000000'; RPATH: '')
dpkg-shlibdeps: error: cannot find library libxcb-present.so.0 needed by debian/libmali-bifrost-g52-g24p0-x11-wayland-gbm/usr/lib/aarch64-linux-gnu/libmali.so.1.9.0 (ELF format: 'elf64-littleaarch64' abi: '020100b700000000'; RPATH: '')
```

build passed but not tested.
https://github.com/nyanmisaka/libmali-rockchip/actions/runs/12103436899